### PR TITLE
Potential fix for code scanning alert no. 31: Use of externally-controlled format string

### DIFF
--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -915,7 +915,7 @@ class WebSocketService {
         try {
           (listener as EventListener<T>)(data as T);
         } catch (error) {
-          console.error(`Error in event listener for ${event}:`, error);
+          console.error("Error in event listener for %s:", event, error);
         }
       });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/prashantdubeypng/metaverse/security/code-scanning/31](https://github.com/prashantdubeypng/metaverse/security/code-scanning/31)

To fix this problem, user input (the `event` variable) should not be directly included in the format string of a logging function like `console.error`. Instead, the untrusted string should be passed as a format parameter, using a safe format string such as `"Error in event listener for %s:"`, and the value of `event` passed as a separate argument. 

Edit line 918 from:

```ts
console.error(`Error in event listener for ${event}:`, error);
```
to:

```ts
console.error("Error in event listener for %s:", event, error);
```

This ensures any format specifiers in `event` are treated as literal strings, not as part of the format string for logging. There is no need to add imports or helper methods for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error logging formatting for better consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->